### PR TITLE
Explicitly close files to prevent resource leak

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,9 +33,10 @@ def trees_provider():
 def materials_provider():
     import json
 
-    materials_data = json.load(
-        open(os.path.join(TEST_DIR, 'data', 'materiaal.txt')),
-    )['materiaal']
+    path = os.path.join(TEST_DIR, "data", "materiaal.txt")
+    with open(path, "r") as f:
+        materials_data = json.load(f)["materiaal"]
+
     from skosprovider.providers import DictionaryProvider
     from skosprovider.skos import ConceptScheme
     from skosprovider.skos import Label


### PR DESCRIPTION
This pull request fixes a file-handling issue in the tests. The current implementation uses `open()` without explicitly closing the file, which can potentially lead to resource leaks. While Python's garbage collector will eventually close the file once it is no longer referenced, it is generally better practice to explicitly close files or use a context manager.

This change replaces the direct `open()` call with a `with` statement to ensure proper file closure and follow Python best practices. The issue was identified during an ongoing research project.