### PR TITLE
Deprecate skosprovider_rdf (#137)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,27 @@
 skosprovider_rdf
 ================
 
+⚠️ This package is deprecated. Use skosprovider_ instead.
+
+Starting from `skosprovider` 2.0.0 the functionality of this package has been
+merged into the main `skosprovider <https://github.com/OnroerendErfgoed/skosprovider/>`_
+repository. This package will remain usable with ``skosprovider < 2.0.0``, but is
+no longer actively maintained. It is recommended to upgrade to
+``skosprovider >= 2.0.0`` and use ``skosprovider_rdf`` from there.
+
+Migrating to skosprovider 2.0.0
+-------------------------------
+
+1. Uninstall ``skosprovider_rdf`` and install ``skosprovider >= 2.0.0``::
+
+       pip uninstall skosprovider_rdf
+       pip install "skosprovider>=2.0.0"
+
+2. Replace any ``skosprovider_rdf`` imports with their equivalent under
+   ``skosprovider`` (see the `skosprovider
+   <https://github.com/OnroerendErfgoed/skosprovider/>`_ documentation for the
+   full mapping).
+
 An implementation of the skosprovider_ interface that supports various RDF
 serialisations through RDFLib.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,16 @@
 Welcome to Skosprovider_rdf's documentation!
 ===================================================
 
-This library offers an implementation of the 
+.. warning::
+
+   This package is deprecated. Starting from ``skosprovider`` 2.0.0 the
+   functionality of this package has been merged into the main
+   `skosprovider <https://github.com/OnroerendErfgoed/skosprovider/>`_
+   repository. This package will remain usable with ``skosprovider < 2.0.0``,
+   but is no longer actively maintained. It is recommended to upgrade to
+   ``skosprovider >= 2.0.0`` and use ``skosprovider_rdf`` from there.
+
+This library offers an implementation of the
 :class:`skosprovider.providers.VocabularyProvider`
 interface that uses an RDFlib_ graph as input. 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "skosprovider_rdf"
 requires-python = ">=3.11,<3.13"
 keywords = ["rdf", "skos", "skosprovider", "vocabularies", "thesauri"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 7 - Inactive",
     "Programming Language :: Python",
     "Framework :: Pyramid",
     "Topic :: Internet :: WWW/HTTP",
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "skosprovider>=1.2.0",
+    "skosprovider>=1.2.0,<2.0.0",
     "rdflib>=6.2.0,<7.0.0",
     "html5lib>=1.1",
 ]

--- a/skosprovider_rdf/__init__.py
+++ b/skosprovider_rdf/__init__.py
@@ -1,0 +1,7 @@
+import warnings
+
+warnings.warn(
+    'skosprovider_rdf is deprecated. Please use `skosprovider>=2.0.0` instead.',
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
## Summary
- Add deprecation banner to README and `.. warning::` block in docs
- Emit `DeprecationWarning` on package import
- Cap `skosprovider` dependency to `<2.0.0` and mark package as `Development Status :: 7 - Inactive`
- Add short migration section pointing to the merged `skosprovider` repo

Refs #137. Version bump and `HISTORY.rst` entry will be added by admin with the final release.